### PR TITLE
Add a Binder badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jupyterlab-kernelspy
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/vidartf/jupyterlab-kernelspy/master?urlpath=%2Flab)
+
 A JupyterLab extension for inspecting messages to/from a kernel.
 
 ![screenshot](screenshot.png)


### PR DESCRIPTION
No extra files required, as `repo2docker` can use the existing `setup.py`.