### PR TITLE
Distinguish prod and dev dependentbot update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
     commit-message:
       prefix: "npm"
       include: "scope"
+    allow:  # Only consider run time dependencies:
+      - dependency-type: "production"
+    ignore: # Don't update major and minor to keep compatibility with older jupyterlab
+      - update-types: ["version-update:semver-major", "version-update:semver-minor"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "dep prod"
+      prefix-development: "dep dev"
+      include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,5 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "dep prod"
-      prefix-development: "dep dev"
+      prefix: "npm"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    versioning-strategy: lockfile-only
     commit-message:
       prefix: "npm"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,4 +16,5 @@ updates:
     allow:  # Only consider run time dependencies:
       - dependency-type: "production"
     ignore: # Don't update major and minor to keep compatibility with older jupyterlab
-      - update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: '*'
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]


### PR DESCRIPTION
cc @vidartf 

i found out that we can ask the bot to tell use if the update is targeting production or dev dependencies